### PR TITLE
don't vertical center align hinttext

### DIFF
--- a/styles/widget.tss
+++ b/styles/widget.tss
@@ -1,6 +1,7 @@
 "TextArea": {}
 
 "#label": {
+        top: 8,
 	left: 8,
 	color: '#ccc'
 }


### PR DESCRIPTION
Hinttext usually isn't vertically center aligned. This fixes it
